### PR TITLE
Change the type declaration of weights_t members

### DIFF
--- a/include/parameters.h
+++ b/include/parameters.h
@@ -14,11 +14,11 @@ typedef struct __setup_time_parameters_t {
 
 
 typedef struct weights_t {
-    int WEIGHT_SETUP_TIMES;
-    int WEIGHT_TOTAL_COMPLETION_TIME;
-    int WEIGHT_MAX_SETUP_TIMES;
-    int WEIGHT_CR;
-    int WEIGHT_TR;
+    float WEIGHT_SETUP_TIMES;
+    float WEIGHT_TOTAL_COMPLETION_TIME;
+    float WEIGHT_MAX_SETUP_TIMES;
+    float WEIGHT_CR;
+    float WEIGHT_TR;
 } weights_t;
 
 typedef struct scheduling_parameters_t {

--- a/main.cpp
+++ b/main.cpp
@@ -177,13 +177,13 @@ void run(thread_data_t *data)
                 .weights =
                     {
                         .WEIGHT_SETUP_TIMES =
-                            stoi(arguments["weight_setup_times"]),
+                            stof(arguments["weight_setup_times"]),
                         .WEIGHT_TOTAL_COMPLETION_TIME =
-                            stoi(arguments["weight_total_completion_time"]),
+                            stof(arguments["weight_total_completion_time"]),
                         .WEIGHT_MAX_SETUP_TIMES =
-                            stoi(arguments["weight_max_setup_times"]),
-                        .WEIGHT_CR = stoi(arguments["weight_cr"]),
-                        .WEIGHT_TR = stoi(arguments["weight_tr"]),
+                            stof(arguments["weight_max_setup_times"]),
+                        .WEIGHT_CR = stof(arguments["weight_cr"]),
+                        .WEIGHT_TR = stof(arguments["weight_tr"]),
                     },
                 .setup_times_parameters =
                     {


### PR DESCRIPTION
In the previous version, the member in weights_t
is declared in integer type and which is not friendly useful
for experiments to find out the parameter set.
Therefore, I change the type from integer to float and that
is good for conducting more experiments with multiple
parameter sets.

The newly changed structure `weights_t` is shown below.

```c=
typedef struct weights_t {
    float WEIGHT_SETUP_TIMES;
    float WEIGHT_TOTAL_COMPLETION_TIME;
    float WEIGHT_MAX_SETUP_TIMES;
    float WEIGHT_CR;
    float WEIGHT_TR;
} weights_t;
```