### PR TITLE
Sort machines by setup_weight

### DIFF
--- a/include/entity.h
+++ b/include/entity.h
@@ -34,6 +34,7 @@ private:
     double _intime;
     double _setup_time;
     double _ptime;
+    double _ent_weight;
     enum machine_status _status;
     std::string _entity_name;
     std::string _model_name;

--- a/include/machine.h
+++ b/include/machine.h
@@ -43,6 +43,7 @@ typedef struct __machine_t {
     double total_completion_time;
     double quality;
     int setup_times;
+    double setup_weight;
     void *ptr_derived_object;
 } machine_t;
 

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -42,6 +42,7 @@ entity_t::entity_t(map<string, string> elements,
     _entity_name = elements["entity"];
     _model_name = elements["model"];
     _location = elements["location"];
+    _ent_weight = stod(elements["ent_weight"]);
     _setup_time = 0;
     _ptime = 0;
     if (elements["STATUS"].compare("SETUP") == 0)
@@ -210,6 +211,7 @@ machine_t entity_t::machine()
                   .total_completion_time = 0,
                   .quality = 0,
                   .setup_times = 0,
+                  .setup_weight = _ent_weight,
                   .ptr_derived_object = nullptr};
 
     machine.current_job.base.end_time = _recover_time;

--- a/src/machines.cpp
+++ b/src/machines.cpp
@@ -210,6 +210,8 @@ int machines_t::_collectScheduledJobs(machine_t *machine,
 
 bool machinePtrComparison(machine_t *m1, machine_t *m2)
 {
+    if (m1->base.available_time == m2->base.available_time)
+        return m1->setup_weight < m2->setup_weight;
     return m1->base.available_time < m2->base.available_time;
 }
 


### PR DESCRIPTION
Originally we sort machines by their available time, now we sort them by their setup_weight.